### PR TITLE
Update to bullseye

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:buster-slim
+FROM debian:bullseye-slim
 
 ARG APP_VERSION
 ARG APP_HASH
@@ -32,7 +32,7 @@ RUN set -ex \
         libusb-0.1-4 \
         libsqlite3-0 \
         curl libcurl4 libcurl4-gnutls-dev \
-        libpython3.7-dev \
+        libpython3.9-dev \
         python3 \
         python3-pip \
     && OS="$(uname -s | sed 'y/ABCDEFGHIJKLMNOPQRSTUVWXYZ/abcdefghijklmnopqrstuvwxyz/')" \
@@ -46,7 +46,6 @@ RUN set -ex \
     && rm domoticz.tgz \
     && mkdir -p /opt/domoticz/userdata \
     && rm -rf /var/lib/apt/lists/* \
-    && ln -s /usr/bin/pip3 /usr/bin/pip \
     && pip3 install setuptools requests
 
 VOLUME /opt/domoticz/userdata


### PR DESCRIPTION
As python 3.7 end of life is approaching (27 Jun 2023), migrate to bullseye and python3.9 is highly recommended.
The generated image can be found on docker hub: sylvainper/domoticz-bullseye:main

Domoticz runs, I haven't done many tests yet but it's working:

Version: 2022.2 (build 15018)
Build Hash: 8ca84a967
Compile Date: 2023-01-31 16:52:49
dzVents Version: 3.1.8
Python Version: 3.9.2 (default, Feb 28 2021, 17:03:44) [GCC 10.2.1 20210110]