### PR TITLE
extends PR26 to address issues with web root

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,6 +51,7 @@ RUN set -ex \
     && pip3 install setuptools requests pyserial
 
 VOLUME /opt/domoticz/userdata
+VOLUME /opt/domoticz/www/templates
 
 EXPOSE 8080
 EXPOSE 443
@@ -68,6 +69,9 @@ COPY docker-entrypoint.sh /usr/local/bin/
 COPY customstart.sh /opt/domoticz/customstart.sh
 RUN chmod +x /usr/local/bin/docker-entrypoint.sh \
     && ln -s usr/local/bin/docker-entrypoint.sh / # backwards compat
+
+# squirrel the web templates (used during self-repair by docker-entrypoint.sh)
+RUN cp -a /opt/domoticz/www/templates /opt/domoticz/www-templates
 
 ENTRYPOINT ["docker-entrypoint.sh"]
 CMD ["/opt/domoticz/domoticz"]

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,7 +1,13 @@
 #!/bin/bash
 
+TEMPLATE="/opt/domoticz"
+USERDATA="${TEMPLATE}/userdata"
+SCRIPTS="${USERDATA}/scripts"
+WEBROOT="${USERDATA}/www"
+
 CMD_ARGS="-www $WWW_PORT"
-CMD_ARGS="$CMD_ARGS -noupdates -sslwww $SSL_PORT -userdata /opt/domoticz/userdata"
+CMD_ARGS="$CMD_ARGS -wwwroot ${WEBROOT}"
+CMD_ARGS="$CMD_ARGS -noupdates -sslwww $SSL_PORT -userdata ${USERDATA}"
 
 if [ -n "$LOG_PATH" ]; then
   CMD_ARGS="$CMD_ARGS -log $LOG_PATH"
@@ -16,27 +22,24 @@ if [ -n "$EXTRA_CMD_ARG" ]; then
 fi
 
 echo "$(date "+%F %T.%3N")  Launch: Begin container self-repair"
-TEMPLATE="/opt/domoticz"
-USERDATA="${TEMPLATE}/userdata"
-SCRIPTS="${USERDATA}/scripts"
 rsync -airp --ignore-existing --mkpath "${TEMPLATE}/plugins/examples"         "${USERDATA}/plugins"
 rsync -airp --ignore-existing          "${TEMPLATE}/customstart.sh"           "${USERDATA}"
-rsync -airp --ignore-existing --mkpath "${TEMPLATE}/www/templates"            "${USERDATA}/www"
+rsync -airp --ignore-existing --mkpath "${TEMPLATE}/www"                      "${USERDATA}"
 rsync -airp --ignore-existing --mkpath "${TEMPLATE}/scripts/dzVents/examples" "${SCRIPTS}/dzVents"
 chown -R 1000:1000 "${USERDATA}"
 echo "$(date "+%F %T.%3N")  Launch: End container self-repair"
 
 # presence of this file implies the container is already configured
-FIRSTRUN="/opt/domoticz/FIRSTRUN"
+FIRSTRUN="${TEMPLATE}/FIRSTRUN"
 
 # perform additional configuration if required
 if [ ! -f "$FIRSTRUN" ] ; then
 
    echo "$(date "+%F %T.%3N")  Launch: Running customstart.sh"
-   source /opt/domoticz/userdata/customstart.sh
+   source ${USERDATA}/customstart.sh
 
    # ensure working directory not changed by customstart script
-   cd /opt/domoticz
+   cd ${TEMPLATE}
 
 fi
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -3,10 +3,9 @@
 TEMPLATE="/opt/domoticz"
 USERDATA="${TEMPLATE}/userdata"
 SCRIPTS="${USERDATA}/scripts"
-WEBROOT="${USERDATA}/www"
+WEBROOT="${TEMPLATE}/www"
 
 CMD_ARGS="-www $WWW_PORT"
-CMD_ARGS="$CMD_ARGS -wwwroot ${WEBROOT}"
 CMD_ARGS="$CMD_ARGS -noupdates -sslwww $SSL_PORT -userdata ${USERDATA}"
 
 if [ -n "$LOG_PATH" ]; then
@@ -24,7 +23,7 @@ fi
 echo "$(date "+%F %T.%3N")  Launch: Begin container self-repair"
 rsync -airp --ignore-existing --mkpath "${TEMPLATE}/plugins/examples"         "${USERDATA}/plugins"
 rsync -airp --ignore-existing          "${TEMPLATE}/customstart.sh"           "${USERDATA}"
-rsync -airp --ignore-existing --mkpath "${TEMPLATE}/www"                      "${USERDATA}"
+rsync -airp                   --mkpath "${TEMPLATE}/www-templates/"           "${WEBROOT}/templates"
 rsync -airp --ignore-existing --mkpath "${TEMPLATE}/scripts/dzVents/examples" "${SCRIPTS}/dzVents"
 chown -R 1000:1000 "${USERDATA}"
 echo "$(date "+%F %T.%3N")  Launch: End container self-repair"


### PR DESCRIPTION
`docker-entrypoint.sh` altered:

1. The `www` folder in the base image is used to non-destructively populate the `www` folder in the persistent store.

   `templates` is a sub-folder of `www` so it is included in the copy.

2. The following additional argument is passed to `domoticz` when it is launched by `docker-entrypoint.sh`:

	```
	-wwwroot /opt/domoticz/userdata/www
	```

	This causes `domoticz` to use the copy of the `www` folder in
	the persistent store.

3. More consistent use of environment variables rather than duplicated path names.